### PR TITLE
Fix license detection on GitHub

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-go-outline
-
 The MIT License (MIT)
 
 Copyright (c) Microsoft Corporation


### PR DESCRIPTION
The first line prevented GitHub from automatically recognizing the license.