### PR TITLE
To differentiate var vs const from *ValueSpec

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 				case *ast.ValueSpec:
 					for _, id := range spec.Names {
 						varOrConst := "variable"
-						if "const" == decl.Tok.String() {
+						if decl.Tok == token.CONST {
 							varOrConst = "constant"
 						}
 						declarations = append(declarations, Declaration{

--- a/main.go
+++ b/main.go
@@ -99,9 +99,13 @@ func main() {
 					})
 				case *ast.ValueSpec:
 					for _, id := range spec.Names {
+						varOrConst := "variable"
+						if "const" == decl.Tok.String() {
+							varOrConst = "constant"
+						}
 						declarations = append(declarations, Declaration{
 							id.Name,
-							"variable",
+							varOrConst,
 							"",
 							id.Pos(),
 							id.End(),


### PR DESCRIPTION
 *ValueSpec consists of token.CONST and token.VAR, needed so that can differentiate constant vs. variable.