### PR TITLE
Code cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		reportError(fmt.Errorf("Could not parse file %s", *file))
 	}
 
-	declarations := []Declaration{}
+	var declarations []Declaration
 
 	for _, decl := range fileAst.Decls {
 		switch decl := decl.(type) {
@@ -121,14 +121,14 @@ func main() {
 		}
 	}
 
-	pkg := []*Declaration{&Declaration{
-		fileAst.Name.String(),
-		"package",
-		"",
-		fileAst.Pos(),
-		fileAst.End(),
-		declarations,
-	}}
+	var pkg []*Declaration
+	pkg = append(pkg, &Declaration{
+		Label:        fileAst.Name.String(),
+		Type:         "package",
+		Start:        fileAst.Pos(),
+		End:          fileAst.End(),
+		Children:     declarations,
+	})
 
 	str, _ := json.Marshal(pkg)
 	fmt.Println(string(str))
@@ -149,5 +149,5 @@ func getReceiverType(fset *token.FileSet, decl *ast.FuncDecl) (string, error) {
 }
 
 func reportError(err error) {
-	fmt.Fprintln(os.Stderr, "error:", err)
+	_, _ = fmt.Fprintln(os.Stderr, "error:", err)
 }

--- a/main.go
+++ b/main.go
@@ -33,15 +33,17 @@ func main() {
 	flag.Parse()
 	fset := token.NewFileSet()
 	parserMode := parser.ParseComments
-	if *importsOnly == true {
+	if *importsOnly {
 		parserMode = parser.ImportsOnly
 	}
 
 	var fileAst *ast.File
 	var err error
 
-	if *modified == true {
-		archive, err := buildutil.ParseOverlayArchive(os.Stdin)
+	if *modified {
+
+		var archive map[string][]byte
+		archive, err = buildutil.ParseOverlayArchive(os.Stdin)
 		if err != nil {
 			reportError(fmt.Errorf("failed to parse -modified archive: %v", err))
 		}


### PR DESCRIPTION
- Correct redundant type warning with the slice `pkg`. 
- Correct warning about ignored error in `fmt.Fprintln()`.
- Simplify code and omit comparison to bool constants 
- Resolve ineffectual assignment to err, where it was shadowed with `buildutil.ParseOverlayArchive(os.Stdin)`